### PR TITLE
Add functions for setting key in context.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,19 @@
+package idempotency
+
+import "context"
+
+type contextKey string
+
+// idempotencyContextKey defines which key to use for context.Context.
+var idempotencyContextKey contextKey = "idempotency-key"
+
+// NewContext returns a new Context that carries value idempotencyKey.
+func NewContext(ctx context.Context, idempotencyKey string) context.Context {
+	return context.WithValue(ctx, idempotencyContextKey, idempotencyKey)
+}
+
+// FromContext returns the Idempotency Key value stored in ctx, if any.
+func FromContext(ctx context.Context) (string, bool) {
+	key, ok := ctx.Value(idempotencyContextKey).(string)
+	return key, ok
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,22 @@
+package idempotency
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	have := "b2ab44c6-ed51-4453-ab00-90779453f2b3"
+	ctx := context.Background()
+
+	withKey := NewContext(ctx, have)
+
+	got, ok := FromContext(withKey)
+	if !ok {
+		t.Errorf("want ok = true, got false")
+	}
+
+	if got != have {
+		t.Errorf("want idempotency key = %v, got %v", have, got)
+	}
+}


### PR DESCRIPTION
This adds NewContext and FromContext that sets a key in the context.
The change might be useful to standardize shipping keys with clients.

Thanks!